### PR TITLE
fix: Remove unnecessary type to fix type error 

### DIFF
--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -6,11 +6,10 @@ import enHome from '@/i18n/locales/en/home.json';
 import enNavbar from '@/i18n/locales/en/navbar.json';
 import esHome from '@/i18n/locales/es/home.json';
 import esNavbar from '@/i18n/locales/es/navbar.json';
-import type { TranslatedResources } from '@/i18n/types';
 
 import { i18nOptions } from './config';
 
-const resources: TranslatedResources = {
+const resources = {
   en: {
     navbar: enNavbar,
     home: enHome,

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -1,5 +1,0 @@
-type TranslatedResource = Record<string, string | Record<string, string>>;
-export type TranslatedResources = {
-  en: Record<string, TranslatedResource>;
-  es: Record<string, TranslatedResource>;
-};


### PR DESCRIPTION
# Summary

This PR fixes a TypeScript type error by removing the explicit type annotation from the `resources` variable.

# Details

The variable `resources` was previously typed as `TranslatedResources`, but this type was unnecessary for two main reasons:

- The `resources` variable is not used anywhere in the application.
- The `i18n` configuration does not require an explicit type for `resources`.

By removing the type annotation, we avoid TypeScript complaining about deep structural mismatches, while keeping the code simpler and cleaner.
